### PR TITLE
Fix mongo port allocation error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - POSTGRES_HOST=host.docker.internal
       - POSTGRES_PORT=5432
       - REDIS_ADDR=host.docker.internal:6379
-      - MONGO_URI=mongodb://host.docker.internal:27017
+      - MONGO_URI=mongodb://mongodb:27017
       - JAEGER_HOST=host.docker.internal:6831
       - KAFKA_BROKERS=host.docker.internal:9092
       - READER_SERVICE=reader_service:5003
@@ -48,7 +48,7 @@ services:
       - POSTGRES_HOST=host.docker.internal
       - POSTGRES_PORT=5432
       - REDIS_ADDR=host.docker.internal:6379
-      - MONGO_URI=mongodb://host.docker.internal:27017
+      - MONGO_URI=mongodb://mongodb:27017
       - JAEGER_HOST=host.docker.internal:6831
       - KAFKA_BROKERS=host.docker.internal:9092
     depends_on:
@@ -78,7 +78,7 @@ services:
       - POSTGRES_HOST=host.docker.internal
       - POSTGRES_PORT=5432
       - REDIS_ADDR=host.docker.internal:6379
-      - MONGO_URI=mongodb://host.docker.internal:27017
+      - MONGO_URI=mongodb://mongodb:27017
       - JAEGER_HOST=host.docker.internal:6831
       - KAFKA_BROKERS=host.docker.internal:9092
     depends_on:
@@ -193,7 +193,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: admin
       MONGODB_DATABASE: products
     ports:
-      - "27017:27017"
+      - "27018:27017"
     volumes:
       - mongodb_data_container:/data/db
     networks: [ "microservices" ]


### PR DESCRIPTION
Update MongoDB port mapping to 27018 and configure services to connect via Docker's internal network to resolve host port conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-366370d3-07e2-4ca5-9d85-bad7b1f4b4d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-366370d3-07e2-4ca5-9d85-bad7b1f4b4d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

